### PR TITLE
Correct for missing preview names and .pty regex

### DIFF
--- a/components/formats-gpl/src/loci/formats/in/FV1000Reader.java
+++ b/components/formats-gpl/src/loci/formats/in/FV1000Reader.java
@@ -458,7 +458,16 @@ public class FV1000Reader extends FormatReader {
         lutNames.add(path + value);
       }
       else if (isPreviewName(value)) {
-        previewNames.add(path + value.trim());
+        try {
+          RandomAccessInputStream s = getFile(path + value.trim());
+          if (s != null) {
+            s.close();
+            previewNames.add(path + value.trim());
+          }
+        }
+        catch (FormatException e) {
+          LOGGER.debug("Preview file not found", e);
+        }
       }
     }
 
@@ -624,7 +633,7 @@ public class FV1000Reader extends FormatReader {
       if (!isOIB && !ptyFile.exists()) {
         LOGGER.warn("Could not find .pty file ({}); guessing at the " +
           "corresponding TIFF file.", file);
-        String tiff = replaceExtension(file, ".pty", ".tif");
+        String tiff = replaceExtension(file, "pty", "tif");
         Location tiffFile = new Location(tiff);
         if (tiffFile.exists()) {
           tiffs.add(ii, tiff);
@@ -660,6 +669,7 @@ public class FV1000Reader extends FormatReader {
           }
           else file = new Location(tiffPath, file).getAbsolutePath();
         }
+        file = replaceExtension(file, "pty", "tif");
         tiffs.add(ii, file);
       }
 
@@ -1366,13 +1376,19 @@ public class FV1000Reader extends FormatReader {
   }
 
   private void addPtyFiles() throws FormatException {
-    if (ptyStart != null && ptyEnd != null && ptyPattern != null) {
+    if (ptyStart != null && ptyEnd != null) {
       // FV1000 version 2 gives the first .pty file, the last .pty and
       // the file name pattern.  Version 1 lists each .pty file individually.
 
       // pattern is typically 's_C%03dT%03d.pty'
 
       // build list of block indexes
+
+      if (ptyPattern == null) {
+        String dir =
+          ptyStart.substring(0, ptyStart.indexOf(File.separator) + 1);
+        ptyPattern = dir + "s_C%03dT%03d.pty";
+      }
 
       String[] prefixes = ptyPattern.split("%03d");
 


### PR DESCRIPTION
Follow-up to dca7f54 which should be the last piece of the puzzle to allow pixel data to be read.
